### PR TITLE
Add timezones endpoint and interfacec definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meticulous-home/espresso-api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meticulous-home/espresso-api",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meticulous-home/espresso-api",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Typescript based package to interact with the meticulous API",
   "author": "Mimoja <mimoja@meticuloushome.com>",
   "license": "GPLv3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,9 @@ import {
   WiFiConfig,
   WiFiCredentials,
   WiFiNetwork,
-  WifiStatus
+  WifiStatus,
+  Regions,
+  regionType
 } from './types';
 
 import { Profile } from '@meticulous-home/espresso-profile';
@@ -347,6 +349,16 @@ export default class Api {
   async getOSStatus(): Promise<AxiosResponse<OSStatusResponse>> {
     return this.axiosInstance.get(
       `/api/${this.version}/machine/OS_update_status`
+    );
+  }
+
+  async getTimezoneRegion(
+    region_type: regionType,
+    conditional: string
+  ): Promise<AxiosResponse<Regions | APIError>> {
+    return this.axiosInstance.get(
+      `/api/${this.version}/timezones/${region_type}`,
+      { params: { filter: conditional } }
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,14 +207,14 @@ export default class Api {
     settingName?: string
   ): Promise<AxiosResponse<Settings | APIError>> {
     const url =
-      `/api/${this.version}/settings` + (settingName ? `/${settingName}` : '');
+      `/api/${this.version}/settings/` + (settingName ? `${settingName}` : '');
     return this.axiosInstance.get(url);
   }
 
   async updateSetting(
     setting: Partial<Settings>
   ): Promise<AxiosResponse<Settings | APIError>> {
-    return this.axiosInstance.post(`/api/${this.version}/settings`, setting);
+    return this.axiosInstance.post(`/api/${this.version}/settings/`, setting);
   }
 
   async updateFirmware(

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,8 @@ export type Settings = Record<SettingsKey, SettingsType> & {
   enable_sounds: boolean;
   save_debug_shot_data: boolean;
   heating_timeout: number;
+  timezone_sync: string;
+  time_zone: string;
 };
 
 export enum APMode {
@@ -311,3 +313,12 @@ export interface OSStatusResponse {
 export interface BrightnessRequest {
   brightness: 0 | 1;
 }
+
+export interface Timezone {
+  [city: string]: string;
+}
+export interface Regions {
+  countries?: string[];
+  cities?: Timezone[];
+}
+export type regionType = 'countries' | 'cities';


### PR DESCRIPTION
New SettingKeys were added to the Record type

timezone_sync: string;
time_zone: string;

Two interfaces were defined to handle timezones endpoint responses

``` js
export interface Timezone {
  [city: string]: string;
}
export interface Regions {
  countries?: string[];
  cities?: Timezone[];
}
```

The fucntion `getTimezoneRegion` was defined to access the tz endpoint to request for a filtered list of valid cuntries / cities with their linked timezone to be shown to the user for selection