### PR TITLE
Functions to fetch manufacturing  mode data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meticulous-home/espresso-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meticulous-home/espresso-api",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meticulous-home/espresso-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Typescript based package to interact with the meticulous API",
   "author": "Mimoja <mimoja@meticuloushome.com>",
   "license": "GPLv3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,8 @@ import {
   WiFiNetwork,
   WifiStatus,
   Regions,
-  regionType
+  regionType,
+  ManufacturingSettings
 } from './types';
 
 import { Profile } from '@meticulous-home/espresso-profile';
@@ -210,6 +211,21 @@ export default class Api {
     setting: Partial<Settings>
   ): Promise<AxiosResponse<Settings | APIError>> {
     return this.axiosInstance.post(`/api/${this.version}/settings/`, setting);
+  }
+  async getManufacturingSettings(): Promise<
+    AxiosResponse<ManufacturingSettings | APIError>
+  > {
+    const url = `/api/${this.version}/settings/manufacturing`;
+    return this.axiosInstance.get(url);
+  }
+
+  async updateManufacturingSettings(
+    setting: Partial<ManufacturingSettings>
+  ): Promise<AxiosResponse<ManufacturingSettings | APIError>> {
+    return this.axiosInstance.post(
+      `/api/${this.version}/settings/manufacturing`,
+      setting
+    );
   }
 
   async updateFirmware(

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,25 @@ export interface LastProfileIdent {
 export type USB_MODE = 'client' | 'host' | 'dual_role';
 export type SettingsType = boolean | number | string;
 
+export type Option = {
+  name: string;
+  type: string;
+  value: boolean;
+};
+export type Element = {
+  key: string;
+  label: string;
+  options: Option[];
+};
+export type ManufacturingSettings = {
+  Elements: Element[];
+};
+
+export type ManufacturingPayload = {
+  persist: boolean;
+  skip_stage: boolean;
+};
+
 export type Settings = {
   auto_preheat: number;
   auto_purge_after_shot: boolean;


### PR DESCRIPTION
## what was change?

Added `getManufacturingSettings | GET` and `updateManufacturingSettings | POST` functions to retrieve and modify manufacturing mode resources.
