### PR TITLE
Feat/debug file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@meticulous-home/espresso-api",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@meticulous-home/espresso-api",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "GPLv3",
       "dependencies": {
         "@meticulous-home/espresso-profile": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meticulous-home/espresso-api",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Typescript based package to interact with the meticulous API",
   "author": "Mimoja <mimoja@meticuloushome.com>",
   "license": "GPLv3",

--- a/src/types.ts
+++ b/src/types.ts
@@ -305,7 +305,7 @@ export interface HistoryBaseEntry {
   name: string;
   profile: HistoryProfile;
   rating?: ShotRating;
-  debug_file: string | null;
+  debug_file?: string | null;
 }
 
 export interface HistoryEntry extends HistoryBaseEntry {


### PR DESCRIPTION
make `HistoryBaseEntry.debug_file` optional, so older backend versions are still compatible