### PR TITLE
Add clock_format_24_hour to Settings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,7 @@ export type Settings = {
   usb_mode: USB_MODE;
   update_channel: string;
   ssh_enabled: boolean;
+  clock_format_24_hour: boolean; 
 };
 
 export type SettingsKey = keyof Settings;


### PR DESCRIPTION
Add `clock_format_24_hour` to the Settings based on [Angel Padilla feedback](https://github.com/MeticulousHome/meticulous-dial/pull/533#pullrequestreview-3725314093).