### PR TITLE
feat: modify MachineAttachments and DraftInfo interfaces

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -201,6 +201,7 @@ export interface MachineAttachments {
   };
   machineLogs?: boolean;
   machineInfo?: boolean;
+  machineStatus?: boolean;
 }
 
 export interface ReportInfo {
@@ -217,6 +218,7 @@ export interface ReportInfo {
 
 export interface DraftInfo {
   localID: string;
+  machineID: string;
 }
 
 export interface SubmitInfo {


### PR DESCRIPTION
add `machineID` to the `DraftInfo` interface and `machineStatus` to the `MachineAttachments` interface